### PR TITLE
Modified `osg-word-count` to handle uploading output files in nested subdirectories.

### DIFF
--- a/ncbi-submit/.gitignore
+++ b/ncbi-submit/.gitignore
@@ -1,3 +1,9 @@
 *.pyc
 testing/
 Dockerfile.local
+bpt/
+bpt.json
+sbt.json
+sqn/
+sqn.json
+sqn.tar.gz

--- a/osg-word-count/Dockerfile
+++ b/osg-word-count/Dockerfile
@@ -13,8 +13,9 @@ RUN wget -qO - https://packages.irods.org/irods-signing-key.asc | apt-key add - 
     && apt-get update \
     && apt-get install -y irods-icommands
 
-# Install the wrapper script.
+# Install the wrapper script and the script to upload the output files.
 ADD wrapper /usr/bin/wrapper
+ADD upload-files /usr/bin/upload-files
 
 # Make the wrapper script the default command.
 CMD ["wrapper"]

--- a/osg-word-count/upload-files
+++ b/osg-word-count/upload-files
@@ -1,0 +1,109 @@
+#!/usr/bin/env python
+
+# Note: this script is only supported on unix-like operating systems.
+
+import argparse
+import os
+import os.path
+import re
+import stat
+import subprocess
+import sys
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Upload files to the data store.")
+    parser.add_argument("-t", "--ticket", required=True, help="The iRODS ticket to use")
+    parser.add_argument("-s", "--sources", nargs="+", help="The files and directories to upload")
+    parser.add_argument("-d", "--dest", required=True, help="The destination directory in iRODS")
+    parser.add_argument("-o", "--owner", required=True, help="The user who should own the uplaoded files")
+    parser.add_argument("-u", "--uploader", required=True, help="The user who is uploading the files")
+    return parser.parse_args()
+
+# Builds the path to an uploaded file.
+def build_upload_path(src, dest):
+    return os.path.join(dest, os.path.basename(src))
+
+# Grants ownership on an iRODS path to a user.
+def grant_ownership(path, user, recursive=False):
+    cmd = ["ichmod", "-r", "own", user, path] if recursive else ["ichmod", "own", user, path]
+    rc = subprocess.call(cmd)
+    if rc != 0:
+        raise Exception("unable to grant ownership permissions for {0} to {1}".format(path, user))
+
+# Revokes permissions on an iRODS path from a user.
+def revoke_permissions(path, user, recursive=False):
+    cmd = ["ichmod", "-r", "null", user, path] if recursive else ["ichmod", "null", user, path]
+    rc = subprocess.call(cmd)
+    if rc != 0:
+        raise Exception("unable to revoke permissions for {0} from {1}").format(path, user)
+
+# Fixes permissions on a path in the data store.
+def fix_permissions(src, dest, owner, uploader, recursive=False):
+    if owner != uploader:
+        path = build_upload_path(src, dest)
+        grant_ownership(path, owner, recursive=recursive)
+        revoke_permissions(path, uploader, recursive=recursive)
+
+# Creates a directory in the data store using a ticket. We can't use imkdir here because imkdir doesn't
+# support tickets. We also can't check for errors because the contents of the subdirectory can't be uploaded
+# and will result in a non-zero exit status.
+def create_directory(src, dest, ticket, owner, uploader):
+    with open("/dev/null", "w") as f:
+        subprocess.call(["iput", "-rt", ticket, src, dest], stdout=f, stderr=f)
+
+# Recursively uploads a file or directory to the data store.
+def upload_recursive(src, dest):
+    mode = os.stat(src).st_mode
+    cmd = None
+    if stat.S_ISDIR(mode):
+        cmd = ["iput", "-r", src, dest]
+    elif stat.S_ISREG(mode):
+        cmd = ["iput", src, dest]
+    else:
+        print >> sys.stderr, "not uploading {0}: unsupported file type".format(src)
+
+    if cmd is not None:
+        rc = subprocess.call(cmd)
+        if rc != 0:
+            raise Exception("unable to upload {0} to {1}".format(src, dest))
+
+# Uploads the contents of a file or directory
+def upload_contents(src, dest):
+    for f in os.listdir(src):
+        upload_recursive(os.path.join(src, f), dest)
+
+# Uploads a single file to the data store.
+def upload_file(src, dest, ticket, owner, uploader):
+    rc = subprocess.call(["iput", "-t", ticket, src, dest])
+    if rc != 0:
+        raise Exception("unable to upload {0} to {1}".format(src, dest))
+    fix_permissions(src, dest, owner, uploader)
+
+# Uploads a directory to the data store.
+def upload_directory(src, dest, ticket, owner, uploader):
+    create_directory(src, dest, ticket, owner, uploader)
+
+    # Build the path to the upload directory.
+    subdir = build_upload_path(src, dest)
+
+    # We have to explicitly grant ownership in case inheritance is enabled.
+    grant_ownership(subdir, uploader)
+
+    # Upload the contents and fix the permissions.
+    upload_contents(src, subdir)
+    fix_permissions(src, dest, owner, uploader, recursive=True)
+
+# Uploads files and directories to the data store.
+def do_upload(sources, dest, ticket, owner, uploader):
+    for src in sources:
+        mode = os.stat(src).st_mode
+        if stat.S_ISDIR(mode):
+            upload_directory(src, dest, ticket, owner, uploader)
+        elif stat.S_ISREG(mode):
+            upload_file(src, dest, ticket, owner, uploader)
+        else:
+            print >> sys.stderr, "not uploading {0}: unsupported file type".format(src)
+
+if __name__ == "__main__":
+    args = parse_args()
+    do_upload(args.sources, args.dest, args.ticket, args.owner, args.uploader)

--- a/osg-word-count/wrapper
+++ b/osg-word-count/wrapper
@@ -114,37 +114,15 @@ def run_job(arguments, output_filename, error_filename):
         if rc != 0:
             raise Exception("wc returned exit code {0}".format(rc))
 
-# Upload a file or directory to iRODS.
-def upload_file(ticket, irods_user, owner, src, dest):
-    rc = subprocess.call(["iput", "-rt", ticket, src, dest])
-    if rc != 0:
-        raise Exception("could not upload {0} to {1}".format(src, dest))
-
-    # Don't bother modifying the file permissions if the iRODS user and file owner are the same.
-    if irods_user == owner:
-        return
-
-    # Update the file permissions so that the person who submitted the job can see the output files.
-    fullpath = os.path.join(dest, src)
-    rc = subprocess.call(["ichmod", "own", owner, fullpath])
-    if rc != 0:
-        raise Exception("could not change the owner of {0} to {1}".format(fullpath, owner))
-    rc = subprocess.call(["ichmod", "null", irods_user, fullpath])
-    if rc != 0:
-        raise Exception("could not remove {0} permissions on {1}".format(irods_user, fullpath))
-
 # Upload a set of files to the directories referenced in a ticket list file to iRODS.
-def upload_files(ticket_list_path, irods_user, owner, files, updater):
+def upload_files(ticket_list_path, irods_user, owner, files):
     failed_uploads = []
     with TicketListReader(ticket_list_path) as tlr:
         for ticket, dest in tlr:
-            for src in files:
-                updater.running("uploading {0} to {1}".format(src, dest))
-                try:
-                    upload_file(ticket, irods_user, owner, src, dest)
-                except Exception as e:
-                    updater.running(e.message)
-                    failed_uploads.append(src)
+            cmd = ["upload-files", "-t", ticket, "-d", dest, "-o", owner, "-u", irods_user, "-s"] + files
+            rc = subprocess.call(cmd)
+            if rc != 0:
+                raise Exception("upload-files exited with status {0}".format(rc))
     if len(failed_uploads) > 0:
         raise Exception("the following files could not be uploaded: {0}".format(failed_uploads))
 
@@ -186,7 +164,7 @@ if __name__ == "__main__":
     # Upload the output files.
     try:
         updater.running("uploading the output files")
-        upload_files(cfg.output_ticket_list, cfg.irods_user, cfg.irods_job_user, [cfg.stdout, cfg.stderr], updater)
+        upload_files(cfg.output_ticket_list, cfg.irods_user, cfg.irods_job_user, [cfg.stdout, cfg.stderr])
     except Exception as e:
         updater.running("unable to upload output files: {0}".format(e))
         job_failed = True


### PR DESCRIPTION
`osg-word-count` doesn't really need this ability, but I wanted to update it because we use it for an example.